### PR TITLE
New stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ As always more features planned. Pull requests are welcome as well.
     - Go to
     - Bring
     - Sit in vehicle
+    - Routingbucket
 2. Administration
     - Kick
     - Ban
@@ -24,12 +25,13 @@ As always more features planned. Pull requests are welcome as well.
     - Give Clothing Menu
     - Give An Item
     - Play A Sound
+    - Mute Player
 4. Player Information List
 
 ![image](https://cdn.discordapp.com/attachments/967850345306914826/969990743747854366/unknown.png)
 
 # Server Management
-![image](https://cdn.discordapp.com/attachments/967850345306914826/969991765396434984/unknown.png)
+![image](https://cdn.discordapp.com/attachments/967850345306914826/970849625621815316/unknown.png)
 
 # Vehicles
 ![image](https://cdn.discordapp.com/attachments/967850345306914826/969991973039669308/unknown.png)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ As always more features planned. Pull requests are welcome as well.
 
 # Server Management
 ![image](https://cdn.discordapp.com/attachments/967850345306914826/970849625621815316/unknown.png)
+![image](https://cdn.discordapp.com/attachments/967850345306914826/970851323656417370/unknown.png)
 
 # Vehicles
 ![image](https://cdn.discordapp.com/attachments/967850345306914826/969991973039669308/unknown.png)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ As always more features planned. Pull requests are welcome as well.
 ![image](https://cdn.discordapp.com/attachments/967850345306914826/969992103356665886/unknown.png)
 
 # Dependencies
-Makes use of both [qb-menu](https://github.com/qbcore-framework/qb-menu) and [qb-input](https://github.com/qbcore-framework/qb-input).
+Makes usage of
+ * [qb-menu](https://github.com/qbcore-framework/qb-menu)
+ * [qb-input](https://github.com/qbcore-framework/qb-input)
+ * [interact-sound](https://github.com/qbcore-framework/interact-sound)
+ * [pma-voice](https://github.com/AvarianKnight/pma-voice)
 
 # License
 

--- a/client/devmenu.lua
+++ b/client/devmenu.lua
@@ -1,3 +1,5 @@
+local vehicleDevMode = false
+local showCoords = false
 
 local function round(input, decimalPlaces)
     return tonumber(string.format("%." .. (decimalPlaces or 0) .. "f", input))

--- a/client/main.lua
+++ b/client/main.lua
@@ -97,6 +97,10 @@ RegisterNetEvent('qb-admin:client:openSoundMenu', function(data)
     soundname = data.name
 end)
 
+RegisterNetEvent('qb-admin:client:openItemMenu', function(data)
+    itemname = data.name
+end)
+
 RegisterNetEvent('qb-admin:client:playsound', function(name, volume, radius)
     TriggerServerEvent('InteractSound_SV:PlayWithinDistance', radius, name, volume)
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,18 +1,8 @@
 QBCore = exports['qb-core']:GetCoreObject()
-banlength = nil
-showCoords = false
-vehicleDevMode = false
 PlayerDetails = nil
-banreason = 'Unknown'
-kickreason = 'Unknown'
-itemname = 'Unknown'
-itemamount = 0
-soundname = 'Unknown'
-soundrange = 0
-soundvolume = 0
 menuLocation = 'topright' -- e.g. topright (default), topleft, bottomright, bottomleft
 menuSize = 'size-125' -- e.g. 'size-100', 'size-110', 'size-125', 'size-150', 'size-175', 'size-200'
-r, g, b = 220, 20, 60 -- red, green, blue values for the menu background
+r, g, b = 20, 255, 236 -- red, green, blue values for the menu background
 
 MainMenu = MenuV:CreateMenu(false, Lang:t("menu.admin_menu"), menuLocation, r, g, b, menuSize, 'qbcore', 'menuv', 'qb-admin:mainmenu')
 SelfMenu = MenuV:CreateMenu(false, Lang:t("menu.admin_options"), menuLocation, r, g, b, menuSize, 'qbcore', 'menuv', 'qb-admin:selfmenu')
@@ -91,14 +81,6 @@ end)
 RegisterNetEvent('qb-admin:client:ToggleCoords', function()
     TriggerServerEvent('qb-admin:server:check')
     ToggleShowCoordinates()
-end)
-
-RegisterNetEvent('qb-admin:client:openSoundMenu', function(data)
-    soundname = data.name
-end)
-
-RegisterNetEvent('qb-admin:client:openItemMenu', function(data)
-    itemname = data.name
 end)
 
 RegisterNetEvent('qb-admin:client:playsound', function(name, volume, radius)

--- a/client/playersmenu.lua
+++ b/client/playersmenu.lua
@@ -561,7 +561,30 @@ function OpenPlayerMenus()
                     TriggerServerEvent('qb-admin:server:'..values, PlayerDetails)
                 end
             })
-        end    
+        end
+        local PlayerGeneralRoutingbucket = PlayerGeneralMenu:AddButton({
+            icon = '🧿',
+            label = Lang:t("menu.routingbucket"),
+            value = "routingbucket",
+            description = Lang:t("desc.routingbucket"),
+            select = function(btn)
+                local dialog = exports['qb-input']:ShowInput({
+                    header = Lang:t("desc.routingbucket"),
+                    submitText = "Confirm",
+                    inputs = {
+                        {
+                            text = "5",
+                            name = "bucket",
+                            type = "number",
+                            isRequired = true
+                        }
+                    }
+                })
+                if dialog then
+                    TriggerServerEvent('qb-admin:server:routingbucket', PlayerDetails, dialog.bucket)
+                end
+            end
+        })
     end)
 
     local PlayersButton2 = PlayerDetailMenu:AddButton({

--- a/client/playersmenu.lua
+++ b/client/playersmenu.lua
@@ -652,6 +652,12 @@ function OpenPlayerMenus()
                 value = "sound",
                 description = Lang:t("desc.play_sound") .. " " .. PlayerDetails.name
             },
+            [5] = {
+                icon = '🔇',
+                label = Lang:t("menu.mute_player"),
+                value = "mute",
+                description = Lang:t("desc.mute_player")
+            },
         }
         for k, v in ipairs(elements) do
             local PlayerExtraButton = PlayerExtraMenu:AddButton({
@@ -667,6 +673,8 @@ function OpenPlayerMenus()
                         MenuV:OpenMenu(GiveItemMenu)
                     elseif values == 'sound' then
                         MenuV:OpenMenu(SoundMenu)
+                    elseif values == 'mute' then
+                        exports['pma-voice']:toggleMutePlayer(PlayerDetails.id)
                     else
                         TriggerServerEvent('qb-admin:server:'..values, PlayerDetails)
                     end
@@ -716,6 +724,10 @@ function OpenPlayerMenus()
     })
     local PlayersButton11 = PlayerDetailMenu:AddButton({
         label = Lang:t("label.gang").. ': ' ..PlayerDetails.gang,
+        description = Lang:t("desc.player_info")
+    })
+    local PlayersButton12 = PlayerDetailMenu:AddButton({
+        label = Lang:t("label.radio").. ': ' ..Player(PlayerDetails.id).state['radioChannel'],
         description = Lang:t("desc.player_info")
     })
 end

--- a/client/playersmenu.lua
+++ b/client/playersmenu.lua
@@ -1,3 +1,12 @@
+local soundname = 'Unknown'
+local soundrange = 0
+local soundvolume = 0
+local itemname = 'Unknown'
+local itemamount = 0
+local banreason = 'Unknown'
+local banlength = nil
+local kickreason = 'Unknown'
+
 local function OpenBanMenu(banplayer)
     MenuV:OpenMenu(BanMenu)
     BanMenu:ClearItems()
@@ -735,3 +744,11 @@ function OpenPlayerMenus()
         description = Lang:t("desc.player_info")
     })
 end
+
+RegisterNetEvent('qb-admin:client:openSoundMenu', function(data)
+    soundname = data.name
+end)
+
+RegisterNetEvent('qb-admin:client:openItemMenu', function(data)
+    itemname = data.name
+end)

--- a/client/playersmenu.lua
+++ b/client/playersmenu.lua
@@ -216,26 +216,58 @@ end
 local function OpenGiveItemMenu(player)
     MenuV:OpenMenu(GiveItemMenu)
     GiveItemMenu:ClearItems()
-    local GiveItemMenuButton1 = GiveItemMenu:AddButton({
+    local GiveItemMenuButton1 = GiveItemMenu:AddSlider({
         icon = '',
         label = Lang:t("info.item"),
         value = "reason",
-        description = Lang:t("desc.item"),
-        select = function(btn)
-            local dialog = exports['qb-input']:ShowInput({
-                header = Lang:t("desc.item"),
-                submitText = "Confirm",
-                inputs = {
+        values = {{
+            label = Lang:t("menu.item_list"),
+            value = '',
+            description = Lang:t("desc.item_list")
+        }, {
+            label = Lang:t("menu.item_self"),
+            value = 'Self',
+            description = Lang:t("desc.item_self")
+        }},
+        select = function(btn, newValue, oldValue)
+            if newValue == 'Self' then
+                local dialog = exports['qb-input']:ShowInput({
+                    header = Lang:t("desc.item_self"),
+                    submitText = "Confirm",
+                    inputs = {
+                        {
+                            text = "Lockpick",
+                            name = "item",
+                            type = "text",
+                            isRequired = true
+                        }
+                    }
+                })
+                if dialog then
+                    itemname = dialog.item
+                end
+            else
+                local ItemMenu = {
                     {
-                        text = "Lockpick",
-                        name = "item",
-                        type = "text",
-                        isRequired = true
+                        header = Lang:t('info.item'),
+                        isMenuHeader = true
                     }
                 }
-            })
-            if dialog then
-                itemname = dialog.item
+    
+                for k, v in pairs(QBCore.Shared.Items) do
+                    ItemMenu[#ItemMenu + 1] = {
+                        header = v['label'],
+                        txt = "",
+                        params = {
+                            event = "qb-admin:client:openItemMenu",
+                            args = {
+                                name = v['name']
+                            }
+                        }
+                    }
+                end
+    
+                exports['qb-menu']:openMenu(ItemMenu)
             end
         end
     })

--- a/client/playersmenu.lua
+++ b/client/playersmenu.lua
@@ -7,502 +7,477 @@ local banreason = 'Unknown'
 local banlength = nil
 local kickreason = 'Unknown'
 
-local function OpenBanMenu(banplayer)
-    MenuV:OpenMenu(BanMenu)
-    BanMenu:ClearItems()
-    local BanMenuButton1 = BanMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.reason"),
-        value = "reason",
-        description = Lang:t("desc.ban_reason"),
-        select = function(btn)
-            local dialog = exports['qb-input']:ShowInput({
-                header = Lang:t("desc.ban_reason"),
-                submitText = "Confirm",
-                inputs = {
-                    {
-                        text = "VDM",
-                        name = "reason",
-                        type = "text",
-                        isRequired = true
-                    }
+local BanMenuButton1 = BanMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.reason"),
+    value = "reason",
+    description = Lang:t("desc.ban_reason"),
+    select = function(btn)
+        local dialog = exports['qb-input']:ShowInput({
+            header = Lang:t("desc.ban_reason"),
+            submitText = "Confirm",
+            inputs = {
+                {
+                    text = "VDM",
+                    name = "reason",
+                    type = "text",
+                    isRequired = true
                 }
-            })
-            if dialog then
-                banreason = dialog.reason
-            end
+            }
+        })
+        if dialog then
+            banreason = dialog.reason
         end
-    })
-
-    local BanMenuButton2 = BanMenu:AddSlider({
-        icon = '⏲️',
-        label = Lang:t("info.length"),
+    end
+})
+local BanMenuButton2 = BanMenu:AddSlider({
+    icon = '⏲️',
+    label = Lang:t("info.length"),
+    value = '3600',
+    values = {{
+        label = Lang:t("time.1hour"),
         value = '3600',
-        values = {{
-            label = Lang:t("time.1hour"),
-            value = '3600',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.6hour"),
-            value ='21600',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.12hour"),
-            value = '43200',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.1day"),
-            value = '86400',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.3day"),
-            value = '259200',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.1week"),
-            value = '604800',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.1month"),
-            value = '2678400',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.3month"),
-            value = '8035200',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.6month"),
-            value = '16070400',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.1year"),
-            value = '32140800',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.permenent"),
-            value = '99999999999',
-            description = Lang:t("time.ban_length")
-        }, {
-            label = Lang:t("time.self"),
-            value = "self",
-            description = Lang:t("time.ban_length")
-        }},
-        select = function(btn, newValue, oldValue)
-            if newValue == "self" then
-                local dialog = exports['qb-input']:ShowInput({
-                    header = 'Ban Length',
-                    submitText = "Confirm",
-                    inputs = {
-                        {
-                            text = "20",
-                            name = "lenght",
-                            type = "number",
-                            isRequired = true
-                        }
-                    }
-                })
-                if dialog then
-                    banlength = dialog.lenght
-                end
-            else
-                banlength = newValue
-            end
-        end
-    })
-
-    local BanMenuButton3 = BanMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.confirm"),
-        value = "ban",
-        description = Lang:t("desc.confirm_ban"),
-        select = function(btn)
-            if banreason ~= 'Unknown' and banlength ~= nil then
-                TriggerServerEvent('qb-admin:server:ban', banplayer, banlength, banreason)
-                banreason = 'Unknown'
-                banlength = nil
-            else
-                QBCore.Functions.Notify(Lang:t("error.invalid_reason_length_ban"), 'error')
-            end
-        end
-    })
-end
-
-local function OpenKickMenu(kickplayer)
-    MenuV:OpenMenu(KickMenu)
-    KickMenu:ClearItems()
-    local KickMenuButton1 = KickMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.reason"),
-        value = "reason",
-        description = Lang:t("desc.kick_reason"),
-        select = function(btn)
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.6hour"),
+        value ='21600',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.12hour"),
+        value = '43200',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.1day"),
+        value = '86400',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.3day"),
+        value = '259200',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.1week"),
+        value = '604800',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.1month"),
+        value = '2678400',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.3month"),
+        value = '8035200',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.6month"),
+        value = '16070400',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.1year"),
+        value = '32140800',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.permenent"),
+        value = '99999999999',
+        description = Lang:t("time.ban_length")
+    }, {
+        label = Lang:t("time.self"),
+        value = "self",
+        description = Lang:t("time.ban_length")
+    }},
+    select = function(btn, newValue, oldValue)
+        if newValue == "self" then
             local dialog = exports['qb-input']:ShowInput({
-                header = Lang:t("desc.kick_reason"),
+                header = 'Ban Length',
                 submitText = "Confirm",
                 inputs = {
                     {
-                        text = "VDM",
-                        name = "reason",
-                        type = "text",
-                        isRequired = true
-                    }
-                }
-            })
-            if dialog then
-                kickreason = dialog.reason
-            end
-        end
-    })
-
-    local KickMenuButton2 = KickMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.confirm"),
-        value = "kick",
-        description = Lang:t("desc.confirm_kick"),
-        select = function(btn)
-            if kickreason ~= 'Unknown' then
-                TriggerServerEvent('qb-admin:server:kick', kickplayer, kickreason)
-                kickreason = 'Unknown'
-            else
-                QBCore.Functions.Notify(Lang:t("error.missing_reason"), 'error')
-            end
-        end
-    })
-end
-
-local function OpenPermsMenu(permsply)
-    local selectedgroup = 'Unknown'
-    MenuV:OpenMenu(PermsMenu)
-    PermsMenu:ClearItems()
-    local PermsMenuButton1 = PermsMenu:AddSlider({
-        icon = '',
-        label = 'Group',
-        value = 'user',
-        values = {{
-            label = 'User',
-            value = 'user',
-            description = 'Group'
-        }, {
-            label = 'Admin',
-            value = 'admin',
-            description = 'Group'
-        }, {
-            label = 'God',
-            value = 'god',
-            description = 'Group'
-        }},
-        change = function(item, newValue, oldValue)
-            local vcal = newValue
-            if vcal == 1 then
-                selectedgroup = {}
-                selectedgroup[#selectedgroup+1] = {rank = "user", label = "User"}
-            elseif vcal == 2 then
-                selectedgroup = {}
-                selectedgroup[#selectedgroup+1] = {rank = "admin", label = "Admin"}
-            elseif vcal == 3 then
-                selectedgroup = {}
-                selectedgroup[#selectedgroup+1] = {rank = "god", label = "God"}
-            end
-        end
-    })
-
-    local PermsMenuButton2 = PermsMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.confirm"),
-        value = "giveperms",
-        description = 'Give the permission group',
-        select = function(btn)
-            if selectedgroup ~= 'Unknown' then
-                TriggerServerEvent('qb-admin:server:setPermissions', permsply.id, selectedgroup)
-                selectedgroup = 'Unknown'
-            else
-                QBCore.Functions.Notify(Lang:t("error.changed_perm_failed"), 'error')
-            end
-        end
-    })
-end
-
-local function OpenGiveItemMenu(player)
-    MenuV:OpenMenu(GiveItemMenu)
-    GiveItemMenu:ClearItems()
-    local GiveItemMenuButton1 = GiveItemMenu:AddSlider({
-        icon = '',
-        label = Lang:t("info.item"),
-        value = "reason",
-        values = {{
-            label = Lang:t("menu.item_list"),
-            value = '',
-            description = Lang:t("desc.item_list")
-        }, {
-            label = Lang:t("menu.item_self"),
-            value = 'Self',
-            description = Lang:t("desc.item_self")
-        }},
-        select = function(btn, newValue, oldValue)
-            if newValue == 'Self' then
-                local dialog = exports['qb-input']:ShowInput({
-                    header = Lang:t("desc.item_self"),
-                    submitText = "Confirm",
-                    inputs = {
-                        {
-                            text = "Lockpick",
-                            name = "item",
-                            type = "text",
-                            isRequired = true
-                        }
-                    }
-                })
-                if dialog then
-                    itemname = dialog.item
-                end
-            else
-                local ItemMenu = {
-                    {
-                        header = Lang:t('info.item'),
-                        isMenuHeader = true
-                    }
-                }
-    
-                for k, v in pairs(QBCore.Shared.Items) do
-                    ItemMenu[#ItemMenu + 1] = {
-                        header = v['label'],
-                        txt = "",
-                        params = {
-                            event = "qb-admin:client:openItemMenu",
-                            args = {
-                                name = v['name']
-                            }
-                        }
-                    }
-                end
-    
-                exports['qb-menu']:openMenu(ItemMenu)
-            end
-        end
-    })
-    local GiveItemMenuButton2 = GiveItemMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.amount"),
-        value = "reason",
-        description = Lang:t("desc.amount"),
-        select = function(btn)
-            local dialog = exports['qb-input']:ShowInput({
-                header = Lang:t("desc.amount"),
-                submitText = "Confirm",
-                inputs = {
-                    {
-                        text = "Lockpick",
-                        name = "amount",
+                        text = "20",
+                        name = "lenght",
                         type = "number",
                         isRequired = true
                     }
                 }
             })
             if dialog then
-                itemamount = dialog.amount
+                banlength = dialog.lenght
             end
+        else
+            banlength = newValue
         end
-    })
-    local GiveItemMenuButton3 = GiveItemMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.confirm"),
-        value = "kick",
-        description = Lang:t("desc.confirm_kick"),
-        select = function(btn)
-            if itemname ~= 'Unknown' and itemamount ~= 0 then
-                TriggerServerEvent('QBCore:CallCommand', "giveitem", {player.id, itemname, itemamount})
-                itemname = 'Unknown'
-                itemamount = 0
-            else
-                QBCore.Functions.Notify(Lang:t("error.give_item"), 'error')
-            end
+    end
+})
+local BanMenuButton3 = BanMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.confirm"),
+    value = "ban",
+    description = Lang:t("desc.confirm_ban"),
+    select = function(btn)
+        if banreason ~= 'Unknown' and banlength ~= nil then
+            TriggerServerEvent('qb-admin:server:ban', PlayerDetails, banlength, banreason)
+            banreason = 'Unknown'
+            banlength = nil
+        else
+            QBCore.Functions.Notify(Lang:t("error.invalid_reason_length_ban"), 'error')
         end
-    })
-end
+    end
+})
 
-local function OpenSoundMenu(player)
-    MenuV:OpenMenu(SoundMenu)
-    SoundMenu:ClearItems()
-    local SoundMenuButton1 = SoundMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.sound"),
-        value = "reason",
-        description = Lang:t("desc.sound"),
-        select = function(btn)
-            TriggerServerEvent('qb-admin:server:getsounds')
+local KickMenuButton1 = KickMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.reason"),
+    value = "reason",
+    description = Lang:t("desc.kick_reason"),
+    select = function(btn)
+        local dialog = exports['qb-input']:ShowInput({
+            header = Lang:t("desc.kick_reason"),
+            submitText = "Confirm",
+            inputs = {
+                {
+                    text = "VDM",
+                    name = "reason",
+                    type = "text",
+                    isRequired = true
+                }
+            }
+        })
+        if dialog then
+            kickreason = dialog.reason
         end
-    })
-    local SoundMenuButton2 = SoundMenu:AddSlider({
-        icon = '',
-        label = Lang:t("volume.volume"),
-        value = '0.5',
-        values = {{
-            label = Lang:t("volume.01"),
-            value = 0.1,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.02"),
-            value = 0.2,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.03"),
-            value = 0.3,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.04"),
-            value = 0.4,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.05"),
-            value = 0.5,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.06"),
-            value = 0.6,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.07"),
-            value = 0.7,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.08"),
-            value = 0.8,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.09"),
-            value = 0.9,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.1.0"),
-            value = 1.0,
-            description = Lang:t("volume.volume")
-        }, {
-            label = Lang:t("volume.self"),
-            value = "self",
-            description = Lang:t("volume.volume")
-        }},
-        description = Lang:t("volume.volume_desc"),
-        select = function(btn, newValue, oldValue)
-            if newValue == "self" then
-                local dialog = exports['qb-input']:ShowInput({
-                    header = Lang:t("volume.volume_desc"),
-                    submitText = "Confirm",
-                    inputs = {
-                        {
-                            text = "0.6",
-                            name = "volume",
-                            type = "text",
-                            isRequired = true
+    end
+})
+local KickMenuButton2 = KickMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.confirm"),
+    value = "kick",
+    description = Lang:t("desc.confirm_kick"),
+    select = function(btn)
+        if kickreason ~= 'Unknown' then
+            TriggerServerEvent('qb-admin:server:kick', PlayerDetails, kickreason)
+            kickreason = 'Unknown'
+        else
+            QBCore.Functions.Notify(Lang:t("error.missing_reason"), 'error')
+        end
+    end
+})
+
+local PermsMenuButton1 = PermsMenu:AddSlider({
+    icon = '',
+    label = 'Group',
+    value = 'user',
+    values = {{
+        label = 'User',
+        value = 'user',
+        description = 'Group'
+    }, {
+        label = 'Admin',
+        value = 'admin',
+        description = 'Group'
+    }, {
+        label = 'God',
+        value = 'god',
+        description = 'Group'
+    }},
+    change = function(item, newValue, oldValue)
+        local vcal = newValue
+        if vcal == 1 then
+            selectedgroup = {}
+            selectedgroup[#selectedgroup+1] = {rank = "user", label = "User"}
+        elseif vcal == 2 then
+            selectedgroup = {}
+            selectedgroup[#selectedgroup+1] = {rank = "admin", label = "Admin"}
+        elseif vcal == 3 then
+            selectedgroup = {}
+            selectedgroup[#selectedgroup+1] = {rank = "god", label = "God"}
+        end
+    end
+})
+local PermsMenuButton2 = PermsMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.confirm"),
+    value = "giveperms",
+    description = 'Give the permission group',
+    select = function(btn)
+        if selectedgroup ~= 'Unknown' then
+            TriggerServerEvent('qb-admin:server:setPermissions', PlayerDetails.id, selectedgroup)
+            selectedgroup = 'Unknown'
+        else
+            QBCore.Functions.Notify(Lang:t("error.changed_perm_failed"), 'error')
+        end
+    end
+})
+
+local GiveItemMenuButton1 = GiveItemMenu:AddSlider({
+    icon = '',
+    label = Lang:t("info.item"),
+    value = "reason",
+    values = {{
+        label = Lang:t("menu.item_list"),
+        value = '',
+        description = Lang:t("desc.item_list")
+    }, {
+        label = Lang:t("menu.item_self"),
+        value = 'Self',
+        description = Lang:t("desc.item_self")
+    }},
+    select = function(btn, newValue, oldValue)
+        if newValue == 'Self' then
+            local dialog = exports['qb-input']:ShowInput({
+                header = Lang:t("desc.item_self"),
+                submitText = "Confirm",
+                inputs = {
+                    {
+                        text = "Lockpick",
+                        name = "item",
+                        type = "text",
+                        isRequired = true
+                    }
+                }
+            })
+            if dialog then
+                itemname = dialog.item
+            end
+        else
+            local ItemMenu = {
+                {
+                    header = Lang:t('info.item'),
+                    isMenuHeader = true
+                }
+            }
+
+            for k, v in pairs(QBCore.Shared.Items) do
+                ItemMenu[#ItemMenu + 1] = {
+                    header = v['label'],
+                    txt = "",
+                    params = {
+                        event = "qb-admin:client:openItemMenu",
+                        args = {
+                            name = v['name']
                         }
                     }
-                })
-                if dialog then
-                    soundvolume = tonumber(dialog.volume)
-                end
-            else
-                soundvolume = newValue
+                }
             end
+
+            exports['qb-menu']:openMenu(ItemMenu)
         end
-    })
-    local SoundMenuButton3 = SoundMenu:AddSlider({
-        icon = '',
-        label = Lang:t("volume.radius"),
-        value = '0.5',
-        values = {{
-            label = Lang:t("volume.10"),
-            value = 10,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.20"),
-            value = 20,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.30"),
-            value = 30,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.40"),
-            value = 40,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.50"),
-            value = 50,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.60"),
-            value = 60,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.70"),
-            value = 70,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.80"),
-            value = 80,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.90"),
-            value = 90,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.100"),
-            value = 100,
-            description = Lang:t("volume.radius")
-        }, {
-            label = Lang:t("volume.self"),
-            value = "self",
-            description = Lang:t("volume.radius")
-        }},
-        description = Lang:t("volume.radius_desc"),
-        select = function(btn, newValue, oldValue)
-            if newValue == "self" then
-                local dialog = exports['qb-input']:ShowInput({
-                    header = Lang:t("volume.radius_desc"),
-                    submitText = "Confirm",
-                    inputs = {
-                        {
-                            text = "30",
-                            name = "volume",
-                            type = "number",
-                            isRequired = true
-                        }
+    end
+})
+local GiveItemMenuButton2 = GiveItemMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.amount"),
+    value = "reason",
+    description = Lang:t("desc.amount"),
+    select = function(btn)
+        local dialog = exports['qb-input']:ShowInput({
+            header = Lang:t("desc.amount"),
+            submitText = "Confirm",
+            inputs = {
+                {
+                    text = "Lockpick",
+                    name = "amount",
+                    type = "number",
+                    isRequired = true
+                }
+            }
+        })
+        if dialog then
+            itemamount = dialog.amount
+        end
+    end
+})
+local GiveItemMenuButton3 = GiveItemMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.confirm"),
+    value = "kick",
+    description = Lang:t("desc.confirm_kick"),
+    select = function(btn)
+        if itemname ~= 'Unknown' and itemamount ~= 0 then
+            TriggerServerEvent('QBCore:CallCommand', "giveitem", {PlayerDetails.id, itemname, itemamount})
+            itemname = 'Unknown'
+            itemamount = 0
+        else
+            QBCore.Functions.Notify(Lang:t("error.give_item"), 'error')
+        end
+    end
+})
+
+local SoundMenuButton1 = SoundMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.sound"),
+    value = "reason",
+    description = Lang:t("desc.sound"),
+    select = function(btn)
+        TriggerServerEvent('qb-admin:server:getsounds')
+    end
+})
+local SoundMenuButton2 = SoundMenu:AddSlider({
+    icon = '',
+    label = Lang:t("volume.volume"),
+    value = '0.5',
+    values = {{
+        label = Lang:t("volume.01"),
+        value = 0.1,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.02"),
+        value = 0.2,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.03"),
+        value = 0.3,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.04"),
+        value = 0.4,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.05"),
+        value = 0.5,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.06"),
+        value = 0.6,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.07"),
+        value = 0.7,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.08"),
+        value = 0.8,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.09"),
+        value = 0.9,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.1.0"),
+        value = 1.0,
+        description = Lang:t("volume.volume")
+    }, {
+        label = Lang:t("volume.self"),
+        value = "self",
+        description = Lang:t("volume.volume")
+    }},
+    description = Lang:t("volume.volume_desc"),
+    select = function(btn, newValue, oldValue)
+        if newValue == "self" then
+            local dialog = exports['qb-input']:ShowInput({
+                header = Lang:t("volume.volume_desc"),
+                submitText = "Confirm",
+                inputs = {
+                    {
+                        text = "0.6",
+                        name = "volume",
+                        type = "text",
+                        isRequired = true
                     }
-                })
-                if dialog then
-                    soundrange = tonumber(dialog.volume)
-                end
-            else
-                soundrange = newValue
+                }
+            })
+            if dialog then
+                soundvolume = tonumber(dialog.volume)
             end
+        else
+            soundvolume = newValue
         end
-    })
-    local SoundMenuButton4 = SoundMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.confirm_play"),
-        value = '',
-        description = Lang:t("desc.confirm_play"),
-        select = function(btn)
-            if soundname ~= 'Unknown' and soundvolume ~= 0 then
-                TriggerServerEvent('InteractSound_SV:PlayOnOne', player.id, soundname, soundvolume)
-            else
-                QBCore.Functions.Notify(Lang:t("error.give_item"), 'error')
+    end
+})
+local SoundMenuButton3 = SoundMenu:AddSlider({
+    icon = '',
+    label = Lang:t("volume.radius"),
+    value = '0.5',
+    values = {{
+        label = Lang:t("volume.10"),
+        value = 10,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.20"),
+        value = 20,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.30"),
+        value = 30,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.40"),
+        value = 40,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.50"),
+        value = 50,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.60"),
+        value = 60,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.70"),
+        value = 70,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.80"),
+        value = 80,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.90"),
+        value = 90,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.100"),
+        value = 100,
+        description = Lang:t("volume.radius")
+    }, {
+        label = Lang:t("volume.self"),
+        value = "self",
+        description = Lang:t("volume.radius")
+    }},
+    description = Lang:t("volume.radius_desc"),
+    select = function(btn, newValue, oldValue)
+        if newValue == "self" then
+            local dialog = exports['qb-input']:ShowInput({
+                header = Lang:t("volume.radius_desc"),
+                submitText = "Confirm",
+                inputs = {
+                    {
+                        text = "30",
+                        name = "volume",
+                        type = "number",
+                        isRequired = true
+                    }
+                }
+            })
+            if dialog then
+                soundrange = tonumber(dialog.volume)
             end
+        else
+            soundrange = newValue
         end
-    })
-    local SoundMenuButton5 = SoundMenu:AddButton({
-        icon = '',
-        label = Lang:t("info.confirm_play_radius"),
-        value = '',
-        description = Lang:t("desc.confirm_play_radius"),
-        select = function(btn)
-            if soundname ~= 'Unknown' and soundvolume ~= 0 and soundrange ~= 0 then
-                TriggerServerEvent('qb-admin:server:playsound', player.id, soundname, soundvolume, soundrange)
-            else
-                QBCore.Functions.Notify(Lang:t("error.give_item"), 'error')
-            end
+    end
+})
+local SoundMenuButton4 = SoundMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.confirm_play"),
+    value = '',
+    description = Lang:t("desc.confirm_play"),
+    select = function(btn)
+        if soundname ~= 'Unknown' and soundvolume ~= 0 then
+            TriggerServerEvent('InteractSound_SV:PlayOnOne', PlayerDetails.id, soundname, soundvolume)
+        else
+            QBCore.Functions.Notify(Lang:t("error.give_item"), 'error')
         end
-    })
-end
+    end
+})
+local SoundMenuButton5 = SoundMenu:AddButton({
+    icon = '',
+    label = Lang:t("info.confirm_play_radius"),
+    value = '',
+    description = Lang:t("desc.confirm_play_radius"),
+    select = function(btn)
+        if soundname ~= 'Unknown' and soundvolume ~= 0 and soundrange ~= 0 then
+            TriggerServerEvent('qb-admin:server:playsound', PlayerDetails.id, soundname, soundvolume, soundrange)
+        else
+            QBCore.Functions.Notify(Lang:t("error.give_item"), 'error')
+        end
+    end
+})
 
 function OpenPlayerMenus()
     PlayerDetailMenu:ClearItems()
@@ -633,11 +608,11 @@ function OpenPlayerMenus()
                 select = function(btn)
                     local values = btn.Value
                     if values == 'ban' then
-                        OpenBanMenu(PlayerDetails)
+                        MenuV:OpenMenu(BanMenu)
                     elseif values == 'kick' then
-                        OpenKickMenu(PlayerDetails)                   
+                        MenuV:OpenMenu(KickMenu)
                     elseif values == 'perms' then
-                        OpenPermsMenu(PlayerDetails)                    
+                        MenuV:OpenMenu(PermsMenu)
                     end
                 end
             })
@@ -689,9 +664,9 @@ function OpenPlayerMenus()
                     if values == 'inventory' then
                         TriggerEvent('qb-admin:client:inventory', PlayerDetails.id)
                     elseif values == 'giveitem' then
-                        OpenGiveItemMenu(PlayerDetails)
+                        MenuV:OpenMenu(GiveItemMenu)
                     elseif values == 'sound' then
-                        OpenSoundMenu(PlayerDetails)
+                        MenuV:OpenMenu(SoundMenu)
                     else
                         TriggerServerEvent('qb-admin:server:'..values, PlayerDetails)
                     end

--- a/client/servermenu.lua
+++ b/client/servermenu.lua
@@ -274,3 +274,48 @@ ServerMenuButton3:On('Select', function(item)
         end
     end)
 end)
+
+local ServerMenuButton4 = ServerMenu:AddButton({
+    icon = '📻',
+    label = Lang:t("info.radio_list"),
+    value = '',
+    description = Lang:t("desc.radio_list"),
+    select = function(btn)
+        local dialog = exports['qb-input']:ShowInput({
+            header = Lang:t("info.radio_list"),
+            submitText = "Confirm",
+            inputs = {
+                {
+                    text = "30",
+                    name = "channel",
+                    type = "number",
+                    isRequired = true
+                }
+            }
+        })
+        if dialog then
+            TriggerServerEvent('qb-admin:server:getradiolist', dialog.channel)
+        end
+    end
+})
+RegisterNetEvent('qb-admin:client:getradiolist', function(data, channel)
+    local RadioMenu = {
+        {
+            header = Lang:t('info.radio_list').. ': ' ..channel,
+            isMenuHeader = true
+        }
+    }
+    for i = 1, #data do
+        RadioMenu[#RadioMenu + 1] = {
+            header = data[i].name,
+            txt = data[i].id,
+            params = {
+                event = "",
+                args = {
+                    name = ''
+                }
+            }
+        }
+    end
+    exports['qb-menu']:openMenu(RadioMenu)
+end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -25,6 +25,7 @@ client_scripts {
 
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
+    'server/config.lua',
     'server/main.lua',
     'server/commands.lua',
 }

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -136,6 +136,7 @@ local Translations = {
         ["ammo"] = "Infinite Ammo",
         ["item_list"] = "Item List",
         ["item_self"] = "Self",
+        ["routingbucket"] = "Routingbucket",
     },
     desc = {
         ["admin_options_desc"] = "Misc. Admin Options",
@@ -186,6 +187,7 @@ local Translations = {
         ["player_info"] = "Extra Player Info",
         ["item_list"] = "Get A Full List Of All Your Items In Your Shared",
         ["item_self"] = "Fill In The Item Name Yourself",
+        ["routingbucket"] = "Teleport This Player To A Different Routingbucket",
     },
     time = {
         ["ban_length"] = "Ban Length",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -134,6 +134,8 @@ local Translations = {
         ["ped"] = "Change Ped Model",
         ["reset_ped"] = "Reset Ped Model",
         ["ammo"] = "Infinite Ammo",
+        ["item_list"] = "Item List",
+        ["item_self"] = "Self",
     },
     desc = {
         ["admin_options_desc"] = "Misc. Admin Options",
@@ -172,7 +174,6 @@ local Translations = {
         ["player_administration"] = "Ban, Kick or give perms to a player",
         ["player_extra_desc"] = "Extra options like giving items etc.",
         ["give_item_menu_desc"] = "Give a specific item to",
-        ["item"] = "Which item to give",
         ["amount"] = "Amount to give",
         ["play_sound"] = "Play A Sound On",
         ["sound"] = "What is the sound file name",
@@ -183,6 +184,8 @@ local Translations = {
         ["reset_ped"] = "Go back to your normal ped",
         ["ammo"] = "Give yourself infinite ammo",
         ["player_info"] = "Extra Player Info",
+        ["item_list"] = "Get A Full List Of All Your Items In Your Shared",
+        ["item_self"] = "Fill In The Item Name Yourself",
     },
     time = {
         ["ban_length"] = "Ban Length",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -76,6 +76,7 @@ local Translations = {
         ["confirm_play"] = "Confirm (Play On Player)",
         ["confirm_play_radius"] = "Confirm (Play Around Player)",
         ["dropped"] = "How are you able to do this?",
+        ["radio_list"] = "Player List From Radio",
     },
     menu = {
         ["admin_menu"] = "Admin Menu",
@@ -137,6 +138,7 @@ local Translations = {
         ["item_list"] = "Item List",
         ["item_self"] = "Self",
         ["routingbucket"] = "Routingbucket",
+        ["mute_player"] = "Mute Player",
     },
     desc = {
         ["admin_options_desc"] = "Misc. Admin Options",
@@ -188,6 +190,8 @@ local Translations = {
         ["item_list"] = "Get A Full List Of All Your Items In Your Shared",
         ["item_self"] = "Fill In The Item Name Yourself",
         ["routingbucket"] = "Teleport This Player To A Different Routingbucket",
+        ["mute_player"] = "Mute Player's Mumble",
+        ["radio_list"] = "Get A Full List Of Players Inside A Certain Radio Frequency",
     },
     time = {
         ["ban_length"] = "Ban Length",
@@ -298,6 +302,7 @@ local Translations = {
         ["bank"] = "Bank Balance",
         ["job"] = "Current Job",
         ["gang"] = "Current Gang",
+        ["radio"] = "Radio Frequency",
     }
 }
 

--- a/server/config.lua
+++ b/server/config.lua
@@ -1,0 +1,34 @@
+--- If this is somehow something else besides interact-sound. Please so change the name of the event that
+--- is triggered when using the play sound option in the menu.
+SoundScriptName = 'interact-sound' -- Name of the sound script that you are using
+SoundPath = '/client/html/sounds' -- Where the sounds are located
+
+--- Who should be able to trigger each NetEvent on the server side?
+permissions = {
+    ['kill'] = 'god',
+    ['revive'] = 'god',
+    ['freeze'] = 'admin',
+    ['spectate'] = 'admin',
+    ['goto'] = 'admin',
+    ['bring'] = 'admin',
+    ['intovehicle'] = 'admin',
+    ['kick'] = 'admin',
+    ['ban'] = 'god',
+    ['setPermissions'] = 'god',
+    ['cloth'] = 'admin',
+    ['spawnVehicle'] = 'admin',
+    ['savecar'] = 'god',
+    ['playsound'] = 'admin',
+    ['usemenu'] = 'admin',
+    ['routingbucket'] = 'admin',
+}
+
+--- Permission hierarchy order from top to bottom. Important for the PermOrder function.
+PermissionOrder = {
+    'god',
+    'admin',
+    'user'
+}
+
+--- Changes the behaviour of the PermOrder function. If set to true it means you still use the database permission system.
+OldPermissionSystem = false

--- a/server/config.lua
+++ b/server/config.lua
@@ -21,6 +21,7 @@ permissions = {
     ['playsound'] = 'admin',
     ['usemenu'] = 'admin',
     ['routingbucket'] = 'admin',
+    ['getradiolist'] = 'admin',
 }
 
 --- Permission hierarchy order from top to bottom. Important for the PermOrder function.

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,38 +1,21 @@
 -- Variables
 QBCore = exports['qb-core']:GetCoreObject()
-local SoundScriptName = 'interact-sound'
-local SoundPath = '/client/html/sounds'
 local Sounds = {}
 local IsFrozen = {}
-local permissions = { -- What should each permission be able to do
-    ['kill'] = 'god',
-    ['revive'] = 'god',
-    ['freeze'] = 'admin',
-    ['spectate'] = 'admin',
-    ['goto'] = 'admin',
-    ['bring'] = 'admin',
-    ['intovehicle'] = 'admin',
-    ['kick'] = 'admin',
-    ['ban'] = 'god',
-    ['setPermissions'] = 'god',
-    ['cloth'] = 'admin',
-    ['spawnVehicle'] = 'admin',
-    ['savecar'] = 'god',
-    ['playsound'] = 'admin',
-    ['usemenu'] = 'admin',
-    ['routingbucket'] = 'admin',
-}
-local PermissionOrder = { -- Permission hierarchy order from top to bottom
-    'god',
-    'admin',
-    'user'
-}
 
--- Functions
+--- Checks what permission the source has and what their ranking is in the permission hierachy.
+--- @param source number - The player's ID
+--- @return number - Ranking of the player in the permission hierachy
 local function PermOrder(source)
     for i = 1, #PermissionOrder do
-        if IsPlayerAceAllowed(source, PermissionOrder[i]) then
-            return i
+        if not OldPermissionSystem then
+            if IsPlayerAceAllowed(source, PermissionOrder[i]) then
+                return i
+            end
+        else
+            if QBCore.Functions.GetPermission(source, PermissionOrder[i]) then
+                return i
+            end
         end
     end
 end
@@ -47,7 +30,6 @@ local function CheckRoutingbucket(source, target)
     if sourceBucket ~= targetBucket then SetPlayerRoutingBucket(source, tonumber(targetBucket)) end
 end
 
--- Events
 RegisterNetEvent('qb-admin:server:GetPlayersForBlips', function()
     local src = source
     local players = {}

--- a/server/main.lua
+++ b/server/main.lua
@@ -245,10 +245,9 @@ end)
 
 RegisterNetEvent('qb-admin:server:getsounds', function()
     local src = source
-    print(Sounds)
+
     if not (QBCore.Functions.HasPermission(src, permissions['playsound'])) then return end
-    print(Sounds)
-    
+
     TriggerClientEvent('qb-admin:client:getsounds', src, Sounds)
 end)
 
@@ -283,6 +282,23 @@ RegisterNetEvent('qb-admin:server:playsound', function(target, soundname, soundv
     if not (QBCore.Functions.HasPermission(src, permissions['playsound'])) then return end
 
     TriggerClientEvent('qb-admin:client:playsound', target, soundname, soundvolume, soundradius)
+end)
+
+RegisterNetEvent('qb-admin:server:getradiolist', function(channel)
+    local src = source
+    local list = exports['pma-voice']:getPlayersInRadioChannel(tonumber(channel))
+    local Players = { id, name }
+
+    if not (QBCore.Functions.HasPermission(src, permissions['getradiolist'])) then return end
+
+    for targetSource, isTalking in pairs(list) do -- cheers Knight who shall not be named
+        local Player = QBCore.Functions.GetPlayer(targetSource)
+        Players[#Players + 1] = {
+            id = targetSource,
+            name = Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' | (' .. GetPlayerName(targetSource) .. ')'
+        }
+    end
+    TriggerClientEvent('qb-admin:client:getradiolist', src, Players, channel)
 end)
 
 RegisterNetEvent('qb-admin:server:check', function()

--- a/server/main.lua
+++ b/server/main.lua
@@ -335,7 +335,3 @@ CreateThread(function()
         Sounds[#Sounds + 1] = filename:match("(.+)%..+$")
     end
 end)
-
-RegisterCommand('routing', function(source, args, raw)
-    print(GetPlayerRoutingBucket(source))
-end)


### PR DESCRIPTION
- Change a player's routingbucket
- Changed both "go to" and "bring" behaviour to prevent previous mentioned routingbucket mess (I can already see admins going crazy not seeing players)
- PMA-Voice integration. Needs testing since I don't have friends. E.g. see in which radio frequency a player is. Mute their mumble. Or get a full player list of players inside a radio frequency.
- Localized variables
- Don't re-create menus that don't have to be re-created
- Backwards compatability with old database permission system
- Proper "config" --> server side.
- Insane documentation on server side functions