### PR TITLE
feat (blips): Compress player blips.

### DIFF
--- a/client/blipsnames.lua
+++ b/client/blipsnames.lua
@@ -82,6 +82,7 @@ RegisterNetEvent('qb-admin:client:Show', function(players)
                 blip = AddBlipForEntity(ped)
                 SetBlipSprite(blip, 1)
                 ShowHeadingIndicatorOnBlip(blip, true)
+                SetBlipCategory(blip, 7)
             else
                 local veh = GetVehiclePedIsIn(ped, false)
                 local blipSprite = GetBlipSprite(blip)


### PR DESCRIPTION
Setting the blip category to 7 which is other players and will compress them into a scrollable list.